### PR TITLE
Improve blog page

### DIFF
--- a/contents/blog/Square869120Contest6-2.md
+++ b/contents/blog/Square869120Contest6-2.md
@@ -5,6 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+category: '競プロ'
 tags: ['AtCoder']
 ---
 

--- a/contents/blog/Square869120Contest6-2.md
+++ b/contents/blog/Square869120Contest6-2.md
@@ -8,8 +8,6 @@ hideAnchor: true
 tags: ['AtCoder']
 ---
 
-tags: [AtCoder](/tags/at-coder)
-
 ## 問題概要
 
 $N$人の買い物客がそれぞれマス$A_i$にある品物とマス$B_i$にある品物を購入する。入り口と出口を設置する時、買い物客は次のように行動する。

--- a/contents/blog/abc-154d.md
+++ b/contents/blog/abc-154d.md
@@ -8,8 +8,6 @@ hideAnchor: true
 tags: ['AtCoder', 'ABC', 'ABC154', '累積和']
 ---
 
-[AtCoder](/tags/at-coder) / [ABC](/tags/abc) / [ABC154](/tags/abc-154) / [累積和](/tags/累積和)
-
 ## 問題概要
 
 $N$個のサイコロから連続する$K$個選んだときの出る目の合計の期待値の最大値を求めよ。

--- a/contents/blog/abc-154d.md
+++ b/contents/blog/abc-154d.md
@@ -5,6 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+category: '競プロ'
 tags: ['AtCoder', 'ABC', 'ABC154', '累積和']
 ---
 

--- a/contents/blog/old_heritage.md
+++ b/contents/blog/old_heritage.md
@@ -5,6 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+category: '競プロ'
 tags: ['AtCoder', 'JOI', '全探索', '二分探索']
 ---
 

--- a/contents/blog/old_heritage.md
+++ b/contents/blog/old_heritage.md
@@ -8,8 +8,6 @@ hideAnchor: true
 tags: ['AtCoder', 'JOI', '全探索', '二分探索']
 ---
 
-[AtCoder](/tags/at-coder) / [JOI](/tags/joi) / [全探索](/tags/全探索) / [二分探索](/tags/二分探索)
-
 ## 問題概要
 
 複数の座標が与えられ、それらの座標を結んでできる正方形のうち面積最大となるものの面積を求めよ。

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,6 +61,7 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
+          `gatsby-remark-responsive-iframe`,
           `gatsby-remark-katex`,
           {
             resolve: `gatsby-remark-autolink-headers`,
@@ -84,6 +85,7 @@ module.exports = {
             resolve: `gatsby-remark-external-links`,
             options: {
               target: '_blank',
+              rel: 'noopener noreferrer',
             },
           },
           {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: 'Portfolio',
+    title: 'a244_note',
   },
   plugins: [
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: 'a244_note',
+    title: 'Portfolio',
   },
   plugins: [
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -96,6 +96,7 @@ module.exports = {
       },
     },
     `gatsby-plugin-remove-trailing-slashes`,
+    `gatsby-plugin-breakpoints`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -7,6 +7,7 @@ module.exports = exports.createPages = ({ actions, graphql }) => {
 
   const postTemplate = path.resolve(`src/templates/postTemplate.js`)
   const tagTemplate = path.resolve(`src/templates/tags.js`)
+  const categoryTemplate = path.resolve(`src/templates/categories.js`)
 
   return graphql(`
     {
@@ -20,9 +21,15 @@ module.exports = exports.createPages = ({ actions, graphql }) => {
               slug
             }
             frontmatter {
+              category
               tags
             }
           }
+        }
+      }
+      categoriesGroup: allMarkdownRemark(limit: 2000) {
+        group(field: frontmatter___category) {
+          fieldValue
         }
       }
       tagsGroup: allMarkdownRemark(limit: 2000) {
@@ -44,6 +51,16 @@ module.exports = exports.createPages = ({ actions, graphql }) => {
       })
     })
 
+    const categories = result.data.categoriesGroup.group
+    categories.forEach(category => {
+      createPage({
+        path: `/categories/${_.kebabCase(category.fieldValue)}`,
+        component: categoryTemplate,
+        context: {
+          category: category.fieldValue,
+        },
+      })
+    })
     const tags = result.data.tagsGroup.group
     tags.forEach(tag => {
       createPage({

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-remark-images": "^3.1.22",
     "gatsby-remark-katex": "^3.1.8",
     "gatsby-remark-prismjs": "^3.3.31",
+    "gatsby-remark-responsive-iframe": "^2.4.17",
     "gatsby-source-filesystem": "^2.1.22",
     "gatsby-transformer-json": "^2.2.8",
     "gatsby-transformer-remark": "^2.6.22",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gatsby": "^2.15.15",
     "gatsby-cli": "^2.7.47",
     "gatsby-image": "^2.2.19",
+    "gatsby-plugin-breakpoints": "^1.2.4",
     "gatsby-plugin-manifest": "^2.2.16",
     "gatsby-plugin-material-ui": "^2.1.10",
     "gatsby-plugin-offline": "^2.2.10",

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -62,7 +62,7 @@ const experiences = [
     term: '2020年６月~現在',
     icon: <HotelIcon />,
     company: '休職中',
-    role: '求職中',
+    role: '',
     description: '現在求職中です。',
   },
 ].reverse()

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import ExperienceTimeLineItem from './ExperienceTimeLineItem'
 import ContentTitle from './ContentTitle'
+import { useBreakpoint } from 'gatsby-plugin-breakpoints'
 import Fade from 'react-reveal/Fade'
-import MediaQuery from 'react-responsive'
 import { makeStyles } from '@material-ui/core/styles'
 import Timeline from '@material-ui/lab/Timeline'
 import FastfoodIcon from '@material-ui/icons/Fastfood'
@@ -79,12 +79,13 @@ const useStyles = makeStyles({
 })
 
 export default function Experience() {
+  const breakpoints = useBreakpoint()
   const classes = useStyles()
   return (
     <>
       <ContentTitle title="Experiences" />
       <Fade bottom>
-        <MediaQuery query="(max-width: 767px)">
+        {breakpoints.sm ? (
           <Timeline align="left">
             <ExperienceTimeLineItem
               experiences={experiences}
@@ -92,8 +93,7 @@ export default function Experience() {
               classes={classes}
             />
           </Timeline>
-        </MediaQuery>
-        <MediaQuery query="(min-width: 768px)">
+        ) : (
           <Timeline align="left">
             <ExperienceTimeLineItem
               experiences={experiences}
@@ -101,7 +101,7 @@ export default function Experience() {
               classes={classes}
             />
           </Timeline>
-        </MediaQuery>
+        )}
       </Fade>
     </>
   )

--- a/src/components/ExperienceTimeLineItem.js
+++ b/src/components/ExperienceTimeLineItem.js
@@ -29,7 +29,7 @@ export default function ExperienceTimeLineItem(props) {
           <Typography variant="h6" component="h1">
             {experience.company}
           </Typography>
-          <Typography variant="h6" component="h2">
+          <Typography variant="h6" component="h3">
             {experience.role}
           </Typography>
           {isNarrow === 'true' && (

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,12 +1,9 @@
 import React from 'react'
-import { Link } from 'gatsby'
 import PCHeader from './PCHeader'
 import { getMenuState } from '../../store/selectors'
 import { connect } from 'react-redux'
+import MediaQuery from 'react-responsive'
 import { makeStyles } from '@material-ui/core/styles'
-import { Typography } from '@material-ui/core'
-import GitHubIcon from '@material-ui/icons/GitHub'
-import TwitterIcon from '@material-ui/icons/Twitter'
 
 const useStyles = makeStyles({
   root: {
@@ -25,7 +22,12 @@ function Header(props) {
 
   return (
     <div className={classes.root}>
-      <PCHeader siteTitle={siteTitle} />
+      <MediaQuery query={'(max-width: 767px'}>
+        <p> hello world</p>
+      </MediaQuery>
+      <MediaQuery query={'(min-width: 768px'}>
+        <PCHeader siteTitle={siteTitle} />
+      </MediaQuery>
     </div>
   )
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -3,7 +3,7 @@ import PCHeader from './PCHeader'
 import MobileHeader from './MobileHeader'
 import { getMenuState } from '../../store/selectors'
 import { connect } from 'react-redux'
-import MediaQuery from 'react-responsive'
+import { useBreakpoint } from 'gatsby-plugin-breakpoints'
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles({
@@ -17,17 +17,17 @@ const useStyles = makeStyles({
 })
 
 function Header(props) {
+  const breakpoints = useBreakpoint()
   const classes = useStyles()
   const { siteTitle } = props
 
   return (
     <div className={classes.root}>
-      <MediaQuery query={'(max-width: 767px'}>
+      {breakpoints.sm ? (
         <MobileHeader siteTitle={siteTitle} />
-      </MediaQuery>
-      <MediaQuery query={'(min-width: 768px'}>
+      ) : (
         <PCHeader siteTitle={siteTitle} />
-      </MediaQuery>
+      )}
     </div>
   )
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,72 +1,46 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Link } from 'gatsby'
 import { getMenuState } from '../../store/selectors'
 import { connect } from 'react-redux'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography } from '@material-ui/core'
 
-class Header extends Component {
-  render() {
-    const { siteTitle, sidebarDocked, menuOpen, nMenuItem } = this.props
+const useStyles = makeStyles({
+  root: {
+    width: '100%',
+    height: 55,
+    marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'cornflowerblue',
+  },
+  headerBlock: {
+    margin: '0 20%',
+  },
+  pageLink: {
+    color: 'white',
+    textDecoration: 'none',
+  },
+})
 
-    return (
-      <div
-        style={{
-          // position: "fixed",
-          // top: 0,
-          width: '100%',
-          height: menuOpen && !sidebarDocked ? nMenuItem * 32 + 50 : 55,
-          marginBottom: 20,
-          background: 'cornflowerblue',
-        }}
-      >
-        <div
-          style={{
-            margin: '0 auto',
-            maxWidth: 1360,
-            padding: '15px 18px',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          <div
-            style={{
-              float: 'left',
-              marginBottom: '10px',
-            }}
-          >
-            <h1 style={{ margin: 0, fontSize: '1.25rem' }}>
-              <Link
-                to="/"
-                style={{
-                  color: 'white',
-                  textDecoration: 'none',
-                }}
-              >
-                {siteTitle}
-              </Link>
-            </h1>
-          </div>
-          <div
-            style={{
-              float: 'right',
-              padding: '0 10px',
-              marginBottom: '10px',
-            }}
-          >
-            <h1 style={{ margin: 0, fontSize: '1.25rem' }}>
-              <Link
-                to="/blog"
-                style={{
-                  color: 'white',
-                  textDecoration: 'none',
-                }}
-              >
-                Blog
-              </Link>
-            </h1>
-          </div>
-        </div>
-      </div>
-    )
-  }
+function Header(props) {
+  const classes = useStyles()
+
+  return (
+    <div className={classes.root}>
+      <Typography variant="h5" className={classes.headerBlock}>
+        <Link to="/" className={classes.pageLink}>
+          Portfolio
+        </Link>
+      </Typography>
+      <Typography variant="h5" className={classes.headerBlock}>
+        <Link to="/blog" className={classes.pageLink}>
+          Blog
+        </Link>
+      </Typography>
+    </div>
+  )
 }
 
 const mapStateToProps = state => {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,44 +1,31 @@
 import React from 'react'
 import { Link } from 'gatsby'
+import PCHeader from './PCHeader'
 import { getMenuState } from '../../store/selectors'
 import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
+import GitHubIcon from '@material-ui/icons/GitHub'
+import TwitterIcon from '@material-ui/icons/Twitter'
 
 const useStyles = makeStyles({
   root: {
     width: '100%',
+    padding: '0 10%',
     height: 55,
     marginBottom: 20,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
     backgroundColor: 'cornflowerblue',
-  },
-  headerBlock: {
-    margin: '0 20%',
-  },
-  pageLink: {
-    color: 'white',
-    textDecoration: 'none',
+    display: 'flex',
   },
 })
 
 function Header(props) {
   const classes = useStyles()
+  const { siteTitle } = props
 
   return (
     <div className={classes.root}>
-      <Typography variant="h5" className={classes.headerBlock}>
-        <Link to="/" className={classes.pageLink}>
-          Portfolio
-        </Link>
-      </Typography>
-      <Typography variant="h5" className={classes.headerBlock}>
-        <Link to="/blog" className={classes.pageLink}>
-          Blog
-        </Link>
-      </Typography>
+      <PCHeader siteTitle={siteTitle} />
     </div>
   )
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PCHeader from './PCHeader'
+import MobileHeader from './MobileHeader'
 import { getMenuState } from '../../store/selectors'
 import { connect } from 'react-redux'
 import MediaQuery from 'react-responsive'
@@ -8,7 +9,6 @@ import { makeStyles } from '@material-ui/core/styles'
 const useStyles = makeStyles({
   root: {
     width: '100%',
-    padding: '0 10%',
     height: 55,
     marginBottom: 20,
     backgroundColor: 'cornflowerblue',
@@ -23,7 +23,7 @@ function Header(props) {
   return (
     <div className={classes.root}>
       <MediaQuery query={'(max-width: 767px'}>
-        <p> hello world</p>
+        <MobileHeader siteTitle={siteTitle} />
       </MediaQuery>
       <MediaQuery query={'(min-width: 768px'}>
         <PCHeader siteTitle={siteTitle} />

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -83,14 +83,21 @@ export default function MobileHeader(props) {
             </Typography>
           </Link>
         </MenuItem>
-        <MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
           <Link to="/blog" className={classes.menuLink}>
             <Typography variant="h5" color="textSecondary">
               Blog
             </Typography>
           </Link>
         </MenuItem>
-        <MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
+          <Link to="/tags" className={classes.menuLink}>
+            <Typography variant="h5" color="textSecondary">
+              Tags
+            </Typography>
+          </Link>
+        </MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
           <a
             href="https://github.com/Atsuyoshi-N"
             className={classes.menuLink}
@@ -102,7 +109,7 @@ export default function MobileHeader(props) {
             </Typography>
           </a>
         </MenuItem>
-        <MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
           <a
             href="https://twitter.com/a244_n"
             className={classes.menuLink}

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -91,9 +91,16 @@ export default function MobileHeader(props) {
           </Link>
         </MenuItem>
         <MenuItem onClick={handleMobileMenuClose}>
+          <Link to="/categories" className={classes.menuLink}>
+            <Typography variant="h5" color="textSecondary">
+              Category
+            </Typography>
+          </Link>
+        </MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
           <Link to="/tags" className={classes.menuLink}>
             <Typography variant="h5" color="textSecondary">
-              Tags
+              Tag
             </Typography>
           </Link>
         </MenuItem>

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -1,0 +1,150 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { makeStyles } from '@material-ui/core/styles'
+import IconButton from '@material-ui/core/IconButton'
+import Typography from '@material-ui/core/Typography'
+import MenuItem from '@material-ui/core/MenuItem'
+import Menu from '@material-ui/core/Menu'
+import MenuIcon from '@material-ui/icons/Menu'
+import GitHubIcon from '@material-ui/icons/GitHub'
+import TwitterIcon from '@material-ui/icons/Twitter'
+
+const useStyles = makeStyles(theme => ({
+  headerContainer: {
+    width: '100%',
+    margin: '0 5%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  times: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '0 5%',
+    width: '100%',
+    borderBottom: '1px solid #666',
+  },
+  pageLink: {
+    color: 'white',
+    textDecoration: 'none',
+  },
+  menuItemRoot: {
+    width: '80vw',
+    height: '100vh',
+  },
+  menuLink: {
+    display: 'block',
+    width: '100%',
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  sectionMobile: {
+    display: 'flex',
+    [theme.breakpoints.up('md')]: {
+      display: 'none',
+    },
+  },
+}))
+
+export default function MobileHeader(props) {
+  const { siteTitle } = props
+  const classes = useStyles()
+  const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = React.useState(null)
+
+  const isMobileMenuOpen = Boolean(mobileMoreAnchorEl)
+
+  const handleMobileMenuClose = () => {
+    setMobileMoreAnchorEl(null)
+  }
+
+  const handleMobileMenuOpen = event => {
+    setMobileMoreAnchorEl(event.currentTarget)
+  }
+
+  const mobileMenuId = 'primary-search-account-menu-mobile'
+  const renderMobileMenu = (
+    <Menu
+      anchorEl={mobileMoreAnchorEl}
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      id={mobileMenuId}
+      keepMounted
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      open={isMobileMenuOpen}
+      onClose={handleMobileMenuClose}
+    >
+      <div className={classes.menuItemRoot}>
+        <MenuItem onClick={handleMobileMenuClose}>
+          <div className={classes.times}>
+            <Typography variant="h5" color="textSecondary">
+              ×
+            </Typography>
+          </div>
+        </MenuItem>
+        <MenuItem onClick={handleMobileMenuClose}>
+          <Link to="/" className={classes.menuLink}>
+            <Typography variant="h5" color="textSecondary">
+              Portfolio
+            </Typography>
+          </Link>
+        </MenuItem>
+        <MenuItem>
+          <Link to="/blog" className={classes.menuLink}>
+            <Typography variant="h5" color="textSecondary">
+              Blog
+            </Typography>
+          </Link>
+        </MenuItem>
+        <MenuItem>
+          <a
+            href="https://github.com/Atsuyoshi-N"
+            className={classes.menuLink}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <Typography variant="h5" color="textSecondary">
+              GitHub
+            </Typography>
+          </a>
+        </MenuItem>
+        <MenuItem>
+          <a
+            href="https://twitter.com/a244_n"
+            className={classes.menuLink}
+            rel="noopener noreferrer"
+            target="_blank"
+            style={{ borderBottom: '1px solid #666' }}
+          >
+            <Typography variant="h5" color="textSecondary">
+              Twitter
+            </Typography>
+          </a>
+        </MenuItem>
+      </div>
+    </Menu>
+  )
+
+  return (
+    <div className={classes.headerContainer}>
+      <div>
+        <Typography variant="h5" className={classes.headerBlock}>
+          <Link to="/" className={classes.pageLink}>
+            {siteTitle}
+          </Link>
+        </Typography>
+      </div>
+      <div className={classes.sectionMobile}>
+        <IconButton
+          aria-label="show more"
+          aria-controls={mobileMenuId}
+          aria-haspopup="true"
+          onClick={handleMobileMenuOpen}
+          color="white"
+        >
+          <MenuIcon />
+        </IconButton>
+      </div>
+      {renderMobileMenu}
+    </div>
+  )
+}

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -36,9 +36,6 @@ const useStyles = makeStyles(theme => ({
     display: 'block',
     width: '100%',
   },
-  menuButton: {
-    marginRight: theme.spacing(2),
-  },
   sectionMobile: {
     display: 'flex',
     [theme.breakpoints.up('md')]: {
@@ -127,7 +124,7 @@ export default function MobileHeader(props) {
   return (
     <div className={classes.headerContainer}>
       <div>
-        <Typography variant="h5" className={classes.headerBlock}>
+        <Typography variant="h5">
           <Link to="/" className={classes.pageLink}>
             {siteTitle}
           </Link>

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -6,8 +6,6 @@ import Typography from '@material-ui/core/Typography'
 import MenuItem from '@material-ui/core/MenuItem'
 import Menu from '@material-ui/core/Menu'
 import MenuIcon from '@material-ui/icons/Menu'
-import GitHubIcon from '@material-ui/icons/GitHub'
-import TwitterIcon from '@material-ui/icons/Twitter'
 
 const useStyles = makeStyles(theme => ({
   headerContainer: {

--- a/src/components/Header/PCHeader.js
+++ b/src/components/Header/PCHeader.js
@@ -6,24 +6,23 @@ import GitHubIcon from '@material-ui/icons/GitHub'
 import TwitterIcon from '@material-ui/icons/Twitter'
 
 const useStyles = makeStyles({
-  headerContainer: {
+  PCHeaderContainer: {
     width: '100%',
     margin: '0 10%',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  headerContainerLeft: {},
+  PCPageLink: {
+    color: 'white',
+    textDecoration: 'none',
+  },
   headerContainerRight: {
     display: 'flex',
     justifyContent: 'flex-end',
     '& > *': {
       padding: '0 7px',
     },
-  },
-  pageLink: {
-    color: 'white',
-    textDecoration: 'none',
   },
   icons: {
     marginTop: '5px',
@@ -35,22 +34,22 @@ export default function PCHeader(props) {
   const { siteTitle } = props
   const classes = useStyles()
   return (
-    <div className={classes.headerContainer}>
-      <div className={classes.headerContainerLeft}>
-        <Typography variant="h5" className={classes.headerBlock}>
-          <Link to="/" className={classes.pageLink}>
+    <div className={classes.PCHeaderContainer}>
+      <div>
+        <Typography variant="h5">
+          <Link to="/" className={classes.PCPageLink}>
             {siteTitle}
           </Link>
         </Typography>
       </div>
       <div className={classes.headerContainerRight}>
-        <Typography variant="h5" className={classes.headerBlock}>
-          <Link to="/" className={classes.pageLink}>
+        <Typography variant="h5">
+          <Link to="/" className={classes.PCPageLink}>
             Portfolio
           </Link>
         </Typography>
-        <Typography variant="h5" className={classes.headerBlock}>
-          <Link to="/blog" className={classes.pageLink}>
+        <Typography variant="h5">
+          <Link to="/blog" className={classes.PCPageLink}>
             Blog
           </Link>
         </Typography>

--- a/src/components/Header/PCHeader.js
+++ b/src/components/Header/PCHeader.js
@@ -53,6 +53,11 @@ export default function PCHeader(props) {
             Blog
           </Link>
         </Typography>
+        <Typography variant="h5">
+          <Link to="/tags" className={classes.PCPageLink}>
+            Tags
+          </Link>
+        </Typography>
         <a
           href="https://github.com/Atsuyoshi-N"
           rel="noopener noreferrer"

--- a/src/components/Header/PCHeader.js
+++ b/src/components/Header/PCHeader.js
@@ -8,6 +8,7 @@ import TwitterIcon from '@material-ui/icons/Twitter'
 const useStyles = makeStyles({
   headerContainer: {
     width: '100%',
+    margin: '0 10%',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/src/components/Header/PCHeader.js
+++ b/src/components/Header/PCHeader.js
@@ -54,8 +54,13 @@ export default function PCHeader(props) {
           </Link>
         </Typography>
         <Typography variant="h5">
+          <Link to="/categories" className={classes.PCPageLink}>
+            Category
+          </Link>
+        </Typography>
+        <Typography variant="h5">
           <Link to="/tags" className={classes.PCPageLink}>
-            Tags
+            Tag
           </Link>
         </Typography>
         <a

--- a/src/components/Header/PCHeader.js
+++ b/src/components/Header/PCHeader.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography } from '@material-ui/core'
+import GitHubIcon from '@material-ui/icons/GitHub'
+import TwitterIcon from '@material-ui/icons/Twitter'
+
+const useStyles = makeStyles({
+  headerContainer: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerContainerLeft: {},
+  headerContainerRight: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    '& > *': {
+      padding: '0 7px',
+    },
+  },
+  pageLink: {
+    color: 'white',
+    textDecoration: 'none',
+  },
+  icons: {
+    marginTop: '5px',
+    color: 'white',
+  },
+})
+
+export default function PCHeader(props) {
+  const { siteTitle } = props
+  const classes = useStyles()
+  return (
+    <div className={classes.headerContainer}>
+      <div className={classes.headerContainerLeft}>
+        <Typography variant="h5" className={classes.headerBlock}>
+          <Link to="/" className={classes.pageLink}>
+            {siteTitle}
+          </Link>
+        </Typography>
+      </div>
+      <div className={classes.headerContainerRight}>
+        <Typography variant="h5" className={classes.headerBlock}>
+          <Link to="/" className={classes.pageLink}>
+            Portfolio
+          </Link>
+        </Typography>
+        <Typography variant="h5" className={classes.headerBlock}>
+          <Link to="/blog" className={classes.pageLink}>
+            Blog
+          </Link>
+        </Typography>
+        <a
+          href="https://github.com/Atsuyoshi-N"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <GitHubIcon className={classes.icons} />
+        </a>
+        <a
+          href="https://twitter.com/a244_n"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <TwitterIcon className={classes.icons} />
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'gatsby'
+import TagList from '../TagList'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
 import Card from 'antd/lib/card'
@@ -16,12 +17,13 @@ export default function PostCard({ post }) {
   const classes = useStyles()
   return (
     <div className={classes.root}>
+      <TagList frontmatter={post.frontmatter} />
       <Card
         marginBottom="30px"
         title={
           <div>
             <Link to={post.fields.slug}>
-              <Typography variant="h5">{post.frontmatter.title}</Typography>
+              <Typography variant="h4">{post.frontmatter.title}</Typography>
             </Link>
             <span
               style={{
@@ -34,10 +36,15 @@ export default function PostCard({ post }) {
           </div>
         }
       >
-        <div
-          className="blog-post-content"
-          dangerouslySetInnerHTML={{ __html: post.html }}
-        />
+        <Typography>
+          <div
+            className="blog-post-content"
+            dangerouslySetInnerHTML={{ __html: post.excerpt }}
+          ></div>
+        </Typography>
+        <Typography align="right" style={{ marginTop: '15px' }}>
+          <Link to={`${post.fields.slug}`}>続きを読む</Link>
+        </Typography>
       </Card>
     </div>
   )

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -1,38 +1,77 @@
 import React from 'react'
 import { Link } from 'gatsby'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography } from '@material-ui/core'
 import Card from 'antd/lib/card'
 import 'antd/lib/card/style/css'
 import 'katex/dist/katex.min.css'
 
-const PostCard = ({ post }) => (
-  <div>
-    <Card
-      marginBottom="30px"
-      title={
-        <div>
-          <Link
-            to={post.fields.slug}
-            style={{ color: 'black', fontWeight: 'bold' }}
-          >
-            {post.frontmatter.title}
-          </Link>
-          <span
-            style={{
-              float: 'right',
-              color: 'grey',
-            }}
-          >
-            {post.frontmatter.date}
-          </span>
-        </div>
-      }
-    >
-      <div
-        className="blog-post-content"
-        dangerouslySetInnerHTML={{ __html: post.html }}
-      />
-    </Card>
-  </div>
-)
+const useStyles = makeStyles({
+  root: {
+    margin: '0 10% 30px',
+  },
+})
 
-export default PostCard
+export default function PostCard({ post }) {
+  const classes = useStyles()
+  return (
+    <div className={classes.root}>
+      <Card
+        marginBottom="30px"
+        title={
+          <div>
+            <Link to={post.fields.slug}>
+              <Typography variant="h5">{post.frontmatter.title}</Typography>
+            </Link>
+            <span
+              style={{
+                float: 'right',
+                color: 'grey',
+              }}
+            >
+              {post.frontmatter.date}
+            </span>
+          </div>
+        }
+      >
+        <div
+          className="blog-post-content"
+          dangerouslySetInnerHTML={{ __html: post.html }}
+        />
+      </Card>
+    </div>
+  )
+}
+
+// const PostCard = ({ post }) => (
+//   <div>
+//     <Card
+//       marginBottom="30px"
+//       title={
+//         <div>
+//           <Link
+//             to={post.fields.slug}
+//             style={{ color: 'black', fontWeight: 'bold' }}
+//           >
+//             {post.frontmatter.title}
+//           </Link>
+//           <span
+//             style={{
+//               float: 'right',
+//               color: 'grey',
+//             }}
+//           >
+//             {post.frontmatter.date}
+//           </span>
+//         </div>
+//       }
+//     >
+//       <div
+//         className="blog-post-content"
+//         dangerouslySetInnerHTML={{ __html: post.html }}
+//       />
+//     </Card>
+//   </div>
+// )
+
+// export default PostCard

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -12,11 +12,14 @@ const useStyles = makeStyles({
     margin: '0 10% 30px',
   },
   postTitleLink: {
-    color: 'cornflowerblue',
     textDecoration: 'none',
     '&:hover': {
+      color: 'cornflowerblue',
       borderBottom: '1px solid cornflowerblue',
     },
+  },
+  readMore: {
+    marginTop: '15px',
   },
 })
 
@@ -42,6 +45,7 @@ export default function PostCard({ post }) {
               <Typography
                 variant="h4"
                 display="inline"
+                color="textSecondary"
                 className={classes.postTitleLink}
               >
                 {post.frontmatter.title}
@@ -57,7 +61,11 @@ export default function PostCard({ post }) {
             dangerouslySetInnerHTML={{ __html: post.excerpt }}
           ></div>
         </Typography>
-        <Typography align="right" style={{ marginTop: '15px' }}>
+        <Typography
+          align="right"
+          variant="subtitle2"
+          className={classes.readMore}
+        >
           <Link to={`${post.fields.slug}`}>続きを読む</Link>
         </Typography>
       </Card>

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -3,12 +3,8 @@ import { Link } from 'gatsby'
 import TagList from '../TagList'
 import { makeStyles } from '@material-ui/core/styles'
 import Card from '@material-ui/core/Card'
-import CardActions from '@material-ui/core/CardActions'
 import CardContent from '@material-ui/core/CardContent'
-import Button from '@material-ui/core/Button'
 import { Typography } from '@material-ui/core'
-// import Card from 'antd/lib/card'
-// import 'antd/lib/card/style/css'
 import 'katex/dist/katex.min.css'
 
 const useStyles = makeStyles({

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -11,31 +11,46 @@ const useStyles = makeStyles({
   root: {
     margin: '0 10% 30px',
   },
+  postTitleLink: {
+    color: 'cornflowerblue',
+    textDecoration: 'none',
+    '&:hover': {
+      borderBottom: '1px solid cornflowerblue',
+    },
+  },
 })
 
 export default function PostCard({ post }) {
   const classes = useStyles()
   return (
     <div className={classes.root}>
-      <TagList frontmatter={post.frontmatter} />
       <Card
         marginBottom="30px"
         title={
           <div>
-            <Link to={post.fields.slug}>
-              <Typography variant="h4">{post.frontmatter.title}</Typography>
-            </Link>
             <span
               style={{
-                float: 'right',
                 color: 'grey',
+                marginBottom: '10px',
               }}
             >
               {post.frontmatter.date}
             </span>
+            <br />
+            <br />
+            <Link to={post.fields.slug}>
+              <Typography
+                variant="h4"
+                display="inline"
+                className={classes.postTitleLink}
+              >
+                {post.frontmatter.title}
+              </Typography>
+            </Link>
           </div>
         }
       >
+        <TagList frontmatter={post.frontmatter} />
         <Typography>
           <div
             className="blog-post-content"

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -2,14 +2,24 @@ import React from 'react'
 import { Link } from 'gatsby'
 import TagList from '../TagList'
 import { makeStyles } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import CardActions from '@material-ui/core/CardActions'
+import CardContent from '@material-ui/core/CardContent'
+import Button from '@material-ui/core/Button'
 import { Typography } from '@material-ui/core'
-import Card from 'antd/lib/card'
-import 'antd/lib/card/style/css'
+// import Card from 'antd/lib/card'
+// import 'antd/lib/card/style/css'
 import 'katex/dist/katex.min.css'
 
 const useStyles = makeStyles({
   root: {
     margin: '0 10% 30px',
+  },
+  date: {
+    marginTop: '10px',
+  },
+  cardContent: {
+    margin: '0 7px',
   },
   postTitleLink: {
     textDecoration: 'none',
@@ -27,81 +37,39 @@ export default function PostCard({ post }) {
   const classes = useStyles()
   return (
     <div className={classes.root}>
-      <Card
-        marginBottom="30px"
-        title={
-          <div>
-            <span
-              style={{
-                color: 'grey',
-                marginBottom: '10px',
-              }}
+      <Card>
+        <CardContent className={classes.cardContent}>
+          <span className={classes.date}>{post.frontmatter.date}</span>
+          <br />
+          <br />
+          <Link to={post.fields.slug}>
+            <Typography
+              variant="h4"
+              display="inline"
+              color="textSecondary"
+              className={classes.postTitleLink}
             >
-              {post.frontmatter.date}
-            </span>
-            <br />
-            <br />
-            <Link to={post.fields.slug}>
-              <Typography
-                variant="h4"
-                display="inline"
-                color="textSecondary"
-                className={classes.postTitleLink}
-              >
-                {post.frontmatter.title}
-              </Typography>
-            </Link>
-          </div>
-        }
-      >
-        <TagList frontmatter={post.frontmatter} />
-        <Typography>
-          <div
-            className="blog-post-content"
-            dangerouslySetInnerHTML={{ __html: post.excerpt }}
-          ></div>
-        </Typography>
-        <Typography
-          align="right"
-          variant="subtitle2"
-          className={classes.readMore}
-        >
-          <Link to={`${post.fields.slug}`}>続きを読む</Link>
-        </Typography>
+              {post.frontmatter.title}
+            </Typography>
+          </Link>
+          <br />
+          <br />
+          <TagList frontmatter={post.frontmatter} />
+          <Typography>
+            <div
+              className="blog-post-content"
+              dangerouslySetInnerHTML={{ __html: post.excerpt }}
+            ></div>
+          </Typography>
+          <Typography
+            align="right"
+            variant="subtitle2"
+            className={classes.readMore}
+          >
+            <Link to={`${post.fields.slug}`}>続きを読む...</Link>
+          </Typography>
+        </CardContent>
       </Card>
     </div>
   )
 }
-
-// const PostCard = ({ post }) => (
-//   <div>
-//     <Card
-//       marginBottom="30px"
-//       title={
-//         <div>
-//           <Link
-//             to={post.fields.slug}
-//             style={{ color: 'black', fontWeight: 'bold' }}
-//           >
-//             {post.frontmatter.title}
-//           </Link>
-//           <span
-//             style={{
-//               float: 'right',
-//               color: 'grey',
-//             }}
-//           >
-//             {post.frontmatter.date}
-//           </span>
-//         </div>
-//       }
-//     >
-//       <div
-//         className="blog-post-content"
-//         dangerouslySetInnerHTML={{ __html: post.html }}
-//       />
-//     </Card>
-//   </div>
-// )
-
-// export default PostCard

--- a/src/components/ResponsiveSidebar/ResponsiveSidebar.js
+++ b/src/components/ResponsiveSidebar/ResponsiveSidebar.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import SidebarContents from '../SidebarContents'
 
 class ResponsiveSidebar extends Component {
   render() {

--- a/src/components/SkillSetCard.js
+++ b/src/components/SkillSetCard.js
@@ -25,7 +25,7 @@ export default function SkillSetCard(props) {
     <Grid item xs={12} sm={6} md={4}>
       <Card className={classes.root} variant="outlined">
         <CardContent>
-          <Typography variant="h5" component="h2">
+          <Typography variant="h5" component="h2" align="center">
             {skillSet.technorogy}
           </Typography>
           <SkillLevelPiChart skillSet={skillSet} />

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -3,17 +3,19 @@ import { Link } from 'gatsby'
 import kebabCase from 'lodash/kebabCase'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
+import LocalOfferIcon from '@material-ui/icons/LocalOffer'
 
 const useStyles = makeStyles({
   tagsList: {
     listStyle: 'none',
     display: 'flex',
+    flexWrap: 'wrap',
     justifyContent: 'flex-start',
     margin: 0,
   },
   tagItem: {
     color: 'rgba(0, 0, 0, 0.54)',
-    margin: '0 10px 0 0',
+    margin: '0 5px 0',
   },
 })
 
@@ -22,6 +24,7 @@ export default function TagList(props) {
   const { frontmatter } = props
   return (
     <ul className={classes.tagsList}>
+      <LocalOfferIcon fontSize="small" />
       {frontmatter.tags !== null &&
         frontmatter.tags.map(tag => (
           <li>

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import kebabCase from 'lodash/kebabCase'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography } from '@material-ui/core'
+
+const useStyles = makeStyles({
+  tagsList: {
+    listStyle: 'none',
+    display: 'flex',
+    justifyContent: 'flex-start',
+  },
+  tagItem: {
+    color: 'rgba(0, 0, 0, 0.54)',
+    margin: '0 10px 0 0',
+  },
+})
+
+export default function TagList(props) {
+  const classes = useStyles()
+  const { frontmatter } = props
+  return (
+    <ul className={classes.tagsList}>
+      {frontmatter.tags !== null &&
+        frontmatter.tags.map(tag => (
+          <li>
+            <Typography variant="subtitle2" color="textSecondary">
+              <Link
+                to={`/tags/${kebabCase(tag)}`}
+                className={classes.tagItem}
+              >{`#${tag}`}</Link>
+            </Typography>
+          </li>
+        ))}
+    </ul>
+  )
+}

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     listStyle: 'none',
     display: 'flex',
     justifyContent: 'flex-start',
+    margin: 0,
   },
   tagItem: {
     color: 'rgba(0, 0, 0, 0.54)',

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
             slug
           }
           id
-          excerpt(format: HTML, pruneLength: 200)
+          excerpt(format: HTML, pruneLength: 200, truncate: true)
           frontmatter {
             date(formatString: "YYYY-MM-DD")
             rootPage

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
             slug
           }
           id
-          excerpt(pruneLength: 300)
+          excerpt(format: HTML, pruneLength: 200)
           frontmatter {
             date(formatString: "YYYY-MM-DD")
             rootPage

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -35,9 +35,10 @@ export const pageQuery = graphql`
           id
           excerpt(pruneLength: 300)
           frontmatter {
-            date(formatString: "MMMM DD, YYYY")
-            title
+            date(formatString: "YYYY-MM-DD")
             rootPage
+            title
+            tags
           }
           html
         }

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
             slug
           }
           id
-          excerpt(format: HTML, pruneLength: 200, truncate: true)
+          excerpt(format: HTML, pruneLength: 100, truncate: true)
           frontmatter {
             date(formatString: "YYYY-MM-DD")
             rootPage

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Layout from '../components/Layout'
+import { Typography } from '@material-ui/core'
+
+// Utilities
+import kebabCase from 'lodash/kebabCase'
+
+// Components
+import { Helmet } from 'react-helmet'
+import { Link, graphql } from 'gatsby'
+
+const CategoryPage = ({
+  data: {
+    allMarkdownRemark: { group },
+    site: {
+      siteMetadata: { title },
+    },
+  },
+}) => (
+  <Layout>
+    <div>
+      <Helmet title={title} />
+      <div style={{ margin: '0 10%' }}>
+        <Typography variant="h5">Categories</Typography>
+        <br />
+        <ul>
+          {group.map(category => (
+            <li key={category.fieldValue}>
+              <Link to={`/categories/${kebabCase(category.fieldValue)}/`}>
+                <Typography>
+                  {category.fieldValue} ({category.totalCount})
+                </Typography>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </Layout>
+)
+
+CategoryPage.propTypes = {
+  data: PropTypes.shape({
+    allMarkdownRemark: PropTypes.shape({
+      group: PropTypes.arrayOf(
+        PropTypes.shape({
+          fieldValue: PropTypes.string.isRequired,
+          totalCount: PropTypes.number.isRequired,
+        }).isRequired
+      ),
+    }),
+    site: PropTypes.shape({
+      siteMetadata: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+      }),
+    }),
+  }),
+}
+
+export default CategoryPage
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    allMarkdownRemark(limit: 2000) {
+      group(field: frontmatter___category) {
+        fieldValue
+        totalCount
+      }
+    }
+  }
+`

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Layout from '../components/Layout'
+import { Typography } from '@material-ui/core'
 
 // Utilities
 import kebabCase from 'lodash/kebabCase'
@@ -20,13 +21,16 @@ const TagsPage = ({
   <Layout>
     <div>
       <Helmet title={title} />
-      <div>
-        <h1>Tags</h1>
+      <div style={{ margin: '0 10%' }}>
+        <Typography variant="h5">Tags</Typography>
+        <br />
         <ul>
           {group.map(tag => (
             <li key={tag.fieldValue}>
               <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
-                {tag.fieldValue} ({tag.totalCount})
+                <Typography>
+                  {tag.fieldValue} ({tag.totalCount})
+                </Typography>
               </Link>
             </li>
           ))}

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -1,8 +1,7 @@
 h2 {
   padding-right: 0;
   font-size: 1.55em;
-  margin-bottom: 1em;
-  margin-top: 1.5em;
+  margin-bottom: 1.5em;
 }
 
 h2:after {

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -1,0 +1,24 @@
+h2 {
+  padding-right: 0;
+  font-size: 1.55em;
+  margin-bottom: 1em;
+  margin-top: 1.5em;
+}
+
+h2:after {
+  display: block;
+  height: 2px;
+  content: '';
+  background: linear-gradient(
+    to right,
+    cornflowerblue 0%,
+    rgba(118, 214, 247, 0.7) 100%
+  );
+}
+
+h3 {
+  font-size: 1.3rem;
+  margin-bottom: 1em;
+  margin-top: 1em;
+  border-bottom: 1px solid #ccc;
+}

--- a/src/styles/codehighlight.css
+++ b/src/styles/codehighlight.css
@@ -1,0 +1,16 @@
+pre[class*='language-'] {
+  background-color: rgb(250, 250, 250);
+  display: block;
+  margin: 0 0 20px;
+  padding-right: 1rem;
+  padding-left: 2rem;
+  border-radius: 0 4px 4px 4px;
+}
+.gatsby-code-title {
+  padding: 0 10px 20px;
+  font-size: 1.2em;
+  line-height: 1.2;
+  font-weight: bold;
+  display: table;
+  border-radius: 4px 4px 0 0;
+}

--- a/src/templates/categories.js
+++ b/src/templates/categories.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PostCard from '../components/PostCard'
+import Layout from '../components/Layout'
+import { Typography } from '@material-ui/core'
+
+// Components
+import { Link, graphql } from 'gatsby'
+
+const Categories = ({ pageContext, data }) => {
+  const { category } = pageContext
+  const { edges, totalCount } = data.allMarkdownRemark
+  const categoryHeader = `${totalCount} post${
+    totalCount === 1 ? '' : 's'
+  } categorized with "${category}"`
+
+  return (
+    <Layout>
+      <div>
+        <Typography variant="h5" align="center" color="textSecondary">
+          {categoryHeader}
+        </Typography>
+        {edges.map(({ node }) => {
+          const { slug } = node.fields
+          return <PostCard key={slug} post={node} />
+        })}
+        {/*
+              This links to a page that does not yet exist.
+              You'll come back to it!
+            */}
+        <Link to="/categories">
+          <Typography
+            variant="h4"
+            align="center"
+            color="primary"
+            style={{
+              color: 'cornflowerblue',
+              '&:hover': {
+                cursor: 'pointer',
+              },
+            }}
+          >
+            View All Categories
+          </Typography>
+        </Link>
+      </div>
+    </Layout>
+  )
+}
+
+Categories.propTypes = {
+  pageContext: PropTypes.shape({
+    category: PropTypes.string.isRequired,
+  }),
+  data: PropTypes.shape({
+    allMarkdownRemark: PropTypes.shape({
+      totalCount: PropTypes.number.isRequired,
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            frontmatter: PropTypes.shape({
+              title: PropTypes.string.isRequired,
+            }),
+            fields: PropTypes.shape({
+              slug: PropTypes.string.isRequired,
+            }),
+          }),
+        }).isRequired
+      ),
+    }),
+  }),
+}
+
+export default Categories
+
+export const pageQuery = graphql`
+  query($category: String) {
+    allMarkdownRemark(
+      limit: 2000
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { category: { eq: $category } } }
+    ) {
+      totalCount
+      edges {
+        node {
+          fields {
+            slug
+          }
+          excerpt(format: HTML, pruneLength: 100, truncate: true)
+          frontmatter {
+            title
+            date(formatString: "YYYY-MM-DD")
+            category
+            tags
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/templates/postTemplate.js
+++ b/src/templates/postTemplate.js
@@ -1,15 +1,33 @@
-import React from "react"
-import { graphql } from "gatsby"
-import Layout from "../components/Layout";
+import React from 'react'
+import { graphql, Link } from 'gatsby'
+import Layout from '../components/Layout'
 import { connect } from 'react-redux'
-import "katex/dist/katex.min.css"
+import kebabCase from 'lodash/kebabCase'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography } from '@material-ui/core'
+import 'katex/dist/katex.min.css'
 import {
   onSidebarContentSelected,
   onSetSidebarContentEntry,
   onSetAnchorHide,
   onSetSidebarHide,
 } from '../actions/layout'
-import { getSidebarSelectedKey, getSidebarEntry } from "../store/selectors";
+import { getSidebarSelectedKey, getSidebarEntry } from '../store/selectors'
+
+const useStyles = makeStyles({
+  blogPostContainer: {
+    margin: '0 15%',
+  },
+  tagsList: {
+    listStyle: 'none',
+    display: 'flex',
+    justifyContent: 'flex-start',
+  },
+  tagItem: {
+    color: 'rgba(0, 0, 0, 0.54)',
+    margin: '0 10px 0 0',
+  },
+})
 
 function Template({
   data, // this prop will be injected by the GraphQL query below.
@@ -18,39 +36,65 @@ function Template({
   onSetSidebarContentEntry,
   sidebarEntry,
   onSetAnchorHide,
-  onSetSidebarHide
+  onSetSidebarHide,
 }) {
   const { markdownRemark } = data // data.markdownRemark holds our post data
   const { frontmatter, html, id } = markdownRemark
 
-  const hideAnchor = (frontmatter.hideAnchor === null) ? false : frontmatter.hideAnchor
-  const hideSidebar = (frontmatter.sidebar === null) ? true : false
+  const classes = useStyles()
+
+  const hideAnchor =
+    frontmatter.hideAnchor === null ? false : frontmatter.hideAnchor
+  const hideSidebar = frontmatter.sidebar === null ? true : false
 
   onSetAnchorHide(hideAnchor)
   onSetSidebarHide(hideSidebar)
 
   if (selectedKey !== id) onSidebarContentSelected(id)
-  if (sidebarEntry !== frontmatter.sidebar) onSetSidebarContentEntry(frontmatter.sidebar)
+  if (sidebarEntry !== frontmatter.sidebar)
+    onSetSidebarContentEntry(frontmatter.sidebar)
 
   return (
     <Layout onPostPage={true}>
-    <div className="blog-post-container">
-      <div className="blog-post">
-        { frontmatter.showTitle && <h1 align="center">{frontmatter.title}</h1> }
-        <div
-          className="blog-post-content"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
+      <div className={classes.blogPostContainer}>
+        <div className={classes.blogPost}>
+          <Typography variant="subtitle1" align="center">
+            {frontmatter.date}
+          </Typography>
+          <br />
+          {frontmatter.showTitle && (
+            <Typography variant="h4" align="center">
+              {frontmatter.title}
+            </Typography>
+          )}
+          <br />
+          <ul className={classes.tagsList}>
+            {frontmatter.tags.map(tag => (
+              <li>
+                <Typography variant="subtitle2" color="textSecondary">
+                  <Link
+                    to={`/tags/${kebabCase(tag)}`}
+                    className={classes.tagItem}
+                  >{`#${tag}`}</Link>
+                </Typography>
+              </li>
+            ))}
+          </ul>
+          <Typography dangerouslySetInnerHTML={{ __html: html }}></Typography>
+          {/* <div
+            className="blog-post-content"
+            dangerouslySetInnerHTML={{ __html: html }}
+          /> */}
+        </div>
       </div>
-    </div>
     </Layout>
   )
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     selectedKey: getSidebarSelectedKey(state),
-    sidebarEntry: getSidebarEntry(state)
+    sidebarEntry: getSidebarEntry(state),
   }
 }
 
@@ -58,25 +102,26 @@ const mapDispatchToProps = {
   onSidebarContentSelected,
   onSetSidebarContentEntry,
   onSetAnchorHide,
-  onSetSidebarHide
+  onSetSidebarHide,
 }
 
-export default connect(mapStateToProps, mapDispatchToProps) (Template)
+export default connect(mapStateToProps, mapDispatchToProps)(Template)
 
 export const pageQuery = graphql`
   query($path: String!) {
-    markdownRemark(fields: { slug: { eq: $path} }) {
+    markdownRemark(fields: { slug: { eq: $path } }) {
       fields {
         slug
       }
       id
       html
       frontmatter {
-        date(formatString: "MMMM DD, YYYY")
+        date(formatString: "YYYY-MM-DD")
         title
         sidebar
         showTitle
         hideAnchor
+        tags
       }
     }
   }

--- a/src/templates/postTemplate.js
+++ b/src/templates/postTemplate.js
@@ -6,6 +6,8 @@ import kebabCase from 'lodash/kebabCase'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
 import 'katex/dist/katex.min.css'
+import '../styles/blog.css'
+import '../styles/codehighlight.css'
 import {
   onSidebarContentSelected,
   onSetSidebarContentEntry,

--- a/src/templates/postTemplate.js
+++ b/src/templates/postTemplate.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { graphql, Link } from 'gatsby'
+import { graphql } from 'gatsby'
+import TagList from '../components/TagList'
 import Layout from '../components/Layout'
 import { connect } from 'react-redux'
-import kebabCase from 'lodash/kebabCase'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
 import 'katex/dist/katex.min.css'
@@ -19,15 +19,6 @@ import { getSidebarSelectedKey, getSidebarEntry } from '../store/selectors'
 const useStyles = makeStyles({
   blogPostContainer: {
     margin: '0 15%',
-  },
-  tagsList: {
-    listStyle: 'none',
-    display: 'flex',
-    justifyContent: 'flex-start',
-  },
-  tagItem: {
-    color: 'rgba(0, 0, 0, 0.54)',
-    margin: '0 10px 0 0',
   },
 })
 
@@ -70,18 +61,7 @@ function Template({
             </Typography>
           )}
           <br />
-          <ul className={classes.tagsList}>
-            {frontmatter.tags.map(tag => (
-              <li>
-                <Typography variant="subtitle2" color="textSecondary">
-                  <Link
-                    to={`/tags/${kebabCase(tag)}`}
-                    className={classes.tagItem}
-                  >{`#${tag}`}</Link>
-                </Typography>
-              </li>
-            ))}
-          </ul>
+          <TagList frontmatter={frontmatter} />
           <Typography dangerouslySetInnerHTML={{ __html: html }}></Typography>
           {/* <div
             className="blog-post-content"

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import PostCard from '../components/PostCard'
 import Layout from '../components/Layout'
+import { Typography } from '@material-ui/core'
 
 // Components
 import { Link, graphql } from 'gatsby'
@@ -15,23 +17,32 @@ const Tags = ({ pageContext, data }) => {
   return (
     <Layout>
       <div>
-        <h1>{tagHeader}</h1>
-        <ul>
-          {edges.map(({ node }) => {
-            const { slug } = node.fields
-            const { title } = node.frontmatter
-            return (
-              <li key={slug}>
-                <Link to={slug}>{title}</Link>
-              </li>
-            )
-          })}
-        </ul>
+        <Typography variant="h5" align="center" color="textSecondary">
+          {tagHeader}
+        </Typography>
+        {edges.map(({ node }) => {
+          const { slug } = node.fields
+          return <PostCard key={slug} post={node} />
+        })}
         {/*
               This links to a page that does not yet exist.
               You'll come back to it!
             */}
-        <Link to="/tags">All tags</Link>
+        <Link to="/tags">
+          <Typography
+            variant="h4"
+            align="center"
+            color="primary"
+            style={{
+              color: 'cornflowerblue',
+              '&:hover': {
+                cursor: 'pointer',
+              },
+            }}
+          >
+            View All tags
+          </Typography>
+        </Link>
       </div>
     </Layout>
   )
@@ -75,8 +86,11 @@ export const pageQuery = graphql`
           fields {
             slug
           }
+          excerpt(format: HTML, pruneLength: 100, truncate: true)
           frontmatter {
             title
+            date(formatString: "YYYY-MM-DD")
+            tags
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,7 +989,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -6652,6 +6652,13 @@ gatsby-page-utils@^0.2.30:
     glob "^7.1.6"
     lodash "^4.17.20"
     micromatch "^4.0.2"
+
+gatsby-plugin-breakpoints@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-breakpoints/-/gatsby-plugin-breakpoints-1.2.4.tgz#ba59539228805409eca05d7f9982e1ef135d2380"
+  integrity sha512-hUOwV+Xr0pf4vVQTGrbgeqjo9mcB2RM1K+By8GITwMMZu8ZDPvF6ls0MNdhQJQmdKm3PxerYTnpPPhV6GCplCQ==
+  dependencies:
+    "@babel/runtime" "^7.11.0"
 
 gatsby-plugin-manifest@^2.2.16:
   version "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6907,6 +6907,17 @@ gatsby-remark-prismjs@^3.3.31:
     parse-numeric-range "^0.0.2"
     unist-util-visit "^1.4.1"
 
+gatsby-remark-responsive-iframe@^2.4.17:
+  version "2.4.17"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.4.17.tgz#8e86163d5d644ee764328e764769e9ab4152a75c"
+  integrity sha512-j7EWCGknU4PiLTp2AqO3rAqvXwHiIF77IWV1/R75QLoEYI8/cqFdMSl7v6bT5oQ2J0ghjlrPVzGo0xF1ybj7ZA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    cheerio "^1.0.0-rc.3"
+    common-tags "^1.8.0"
+    lodash "^4.17.20"
+    unist-util-visit "^1.4.1"
+
 gatsby-source-filesystem@^2.1.22:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.4.1.tgz#46e284542c2244ae2a13dcc9d912ef3550dedd64"


### PR DESCRIPTION
## What
- Replace react-responsive with gatsby-plugin-breakpoints
- Separate Header with PCHeader and MobileHeader
- Replace antd-card style with the material-ui card because long title name is not rendered correctly
- cut out the tag-list as a component
- Improve tag lists UI
- Create markdown CSS
- Create category block

## Reference
- Create categories [Creating Tags Pages for Blog Posts](https://www.gatsbyjs.com/docs/adding-tags-and-categories-to-blog-posts/)
- UI is broken when I use makeStyles of material UI with react-responsive on Gatsby [Pythonしか触ったことのなかった大学生がReact(Gatsby.js)でWeb開発した話 - Qiita](https://qiita.com/horri1520/items/cee083e846c01d38b622)