### PR TITLE
Fix dangerouslySetInnerHTML bug

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -153,6 +153,7 @@ module.exports = {
     },
     `gatsby-plugin-remove-trailing-slashes`,
     `gatsby-plugin-breakpoints`,
+    `gatsby-plugin-remove-trailing-slashes`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "styled-components": "^5.2.1",
     "typescript": "^3.6.3"
   },
-  "keywords": ["gatsby"],
+  "keywords": [
+    "gatsby"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
@@ -60,7 +62,7 @@
     "deploy": "gatsby build --prefix-paths && gh-pages -d public -b master"
   },
   "devDependencies": {
-    "gatsby-plugin-remove-trailing-slashes": "^2.1.6",
+    "gatsby-plugin-remove-trailing-slashes": "^2.3.13",
     "gh-pages": "^2.2.0",
     "mem": "^5.1.1",
     "prettier": "^1.18.2",

--- a/src/templates/posts.js
+++ b/src/templates/posts.js
@@ -58,7 +58,7 @@ function Template({
   return (
     <Layout onPostPage={true}>
       <div className={classes.blogPostContainer}>
-        <div className={classes}>
+        <div>
           <Typography variant="subtitle1" align="center">
             {frontmatter.date}
           </Typography>
@@ -70,7 +70,9 @@ function Template({
           )}
           <br />
           <TagList frontmatter={frontmatter} />
-          <Typography dangerouslySetInnerHTML={{ __html: html }}></Typography>
+          <Typography>
+            <div dangerouslySetInnerHTML={{ __html: html }}></div>
+          </Typography>
         </div>
         <PrevNextPost prev={prev} next={next} />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6959,7 +6959,7 @@ gatsby-plugin-react-helmet@^3.1.7:
   dependencies:
     "@babel/runtime" "^7.11.2"
 
-gatsby-plugin-remove-trailing-slashes@^2.1.6:
+gatsby-plugin-remove-trailing-slashes@^2.3.13:
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.3.13.tgz#4e57e8cb7b6f9c0f9c623a09e68d5bbad384940f"
   integrity sha512-38HuqD5+lAaoMukCN2Q2Y5lviR41DogEsBQg9vC8Nh4OBWb3vuXXDyFgfE/oMpgbn7Mv5mUPzRerJGW6HdxCEA==


### PR DESCRIPTION
## What
- Fix dangerouslySetInnerHTML bug

## Why
- When each blog page is loaded, the blog post does not render

## References
- [Gatsby + microCMS + Firestore エラー・不具合集](https://qiita.com/atomyah/items/b8ae87ad7265e46bc6d2)
- [dangerouslySetInnerHTML does not work on production builds](https://github.com/gatsbyjs/gatsby/issues/11108)