### PR TITLE
Introduce google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -157,6 +157,15 @@ module.exports = {
         ],
       },
     },
+    {
+      resolve: `gatsby-plugin-google-gtag`,
+      options: {
+        trackingIds: ['G-X0RNXE5821'],
+        pluginConfig: {
+          head: true,
+        },
+      },
+    },
     `gatsby-plugin-remove-trailing-slashes`,
     `gatsby-plugin-breakpoints`,
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gatsby-plugin-manifest": "^3.6.0",
     "gatsby-plugin-material-ui": "3.0.0",
     "gatsby-plugin-offline": "^4.6.0",
-    "gatsby-plugin-react-helmet": "^4.6.0",
+    "gatsby-plugin-react-helmet": "^5.1.0",
     "gatsby-plugin-sharp": "^3.6.0",
     "gatsby-plugin-styled-components": "^4.5.0",
     "gatsby-remark-autolink-headers": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-image": "^3.6.0",
     "gatsby-plugin-breakpoints": "^1.2.4",
     "gatsby-plugin-feed": "^3.6.0",
+    "gatsby-plugin-google-gtag": "^4.1.0",
     "gatsby-plugin-manifest": "^3.6.0",
     "gatsby-plugin-material-ui": "3.0.0",
     "gatsby-plugin-offline": "^4.6.0",

--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -1,0 +1,61 @@
+// Reference
+// https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/
+// https://github.com/gatsbyjs/gatsby/blob/master/starters/blog/src/components/seo.js
+
+import React from 'react'
+import { Helmet } from 'react-helmet'
+import { useStaticQuery, graphql } from 'gatsby'
+
+const Seo = ({ description, lang, meta, title }) => {
+  const { site } = useStaticQuery(
+    graphql`
+      query {
+        site {
+          siteMetadata {
+            title
+            description
+          }
+        }
+      }
+    `
+  )
+
+  const metaDescription = description || site.siteMetadata.description
+  const defaultTitle = site.siteMetadata?.title
+
+  return (
+    <Helmet
+      htmlAttributes={{
+        lang,
+      }}
+      title={title}
+      titleTemplate={defaultTitle ? `%s | ${defaultTitle}` : null}
+      meta={[
+        {
+          name: `description`,
+          content: metaDescription,
+        },
+        {
+          property: `og:title`,
+          content: title,
+        },
+        {
+          property: `og:description`,
+          content: metaDescription,
+        },
+        {
+          propety: `og:type`,
+          content: `website`,
+        },
+      ].concat(meta)}
+    />
+  )
+}
+
+Seo.defaultProps = {
+  lang: `ja`,
+  meta: [],
+  description: ``,
+}
+
+export default Seo

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '../components/Layout'
 import PostCard from '../components/PostCard'
+import Seo from '../components/Seo'
 
 const BlogPage = ({
   data: {
@@ -14,6 +15,7 @@ const BlogPage = ({
     .map((edge) => <PostCard key={edge.node.id} post={edge.node} />)
   return (
     <Layout location={location}>
+      <Seo title="ブログ記事一覧" description="ブログ記事一覧" />
       <div>{posts}</div>
     </Layout>
   )

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Layout from '../components/Layout'
+import Seo from '../components/Seo'
 import { Typography } from '@material-ui/core'
 
 // Utilities
@@ -20,13 +21,13 @@ const CategoryPage = ({
   location,
 }) => (
   <Layout location={location}>
+    <Seo title="カテゴリー一覧" description="ブログ記事のカテゴリー一覧" />
     <div>
-      <Helmet title={title} />
       <div style={{ margin: '0 10%' }}>
         <Typography variant="h5">Categories</Typography>
         <br />
         <ul>
-          {group.map(category => (
+          {group.map((category) => (
             <li key={category.fieldValue}>
               <Link to={`/categories/${kebabCase(category.fieldValue)}/`}>
                 <Typography>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Layout from '../components/Layout'
 import Experience from '../components/Experience'
 import Profile from '../components/Profile'
+import Seo from '../components/Seo'
 import Skill from '../components/Skill'
 import Work from '../components/Work'
 import { makeStyles } from '@material-ui/core/styles'
@@ -21,6 +22,7 @@ const IndexPage = ({ location }) => {
   const classes = useStyles()
   return (
     <Layout location={location}>
+      <Seo title="Portfolio" description="a244nのポートフォリオ" />
       <Profile />
       <br />
       <Experience />

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Layout from '../components/Layout'
+import Seo from '../components/Seo'
 import { Typography } from '@material-ui/core'
 
 // Utilities
@@ -20,13 +21,13 @@ const TagsPage = ({
   location,
 }) => (
   <Layout location={location}>
+    <Seo title="タグ一覧" description="ブログ記事のタグ一覧" />
     <div>
-      <Helmet title={title} />
       <div style={{ margin: '0 10%' }}>
         <Typography variant="h5">Tags</Typography>
         <br />
         <ul>
-          {group.map(tag => (
+          {group.map((tag) => (
             <li key={tag.fieldValue}>
               <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
                 <Typography>

--- a/src/templates/categories.js
+++ b/src/templates/categories.js
@@ -74,7 +74,7 @@ Categories.propTypes = {
 export default Categories
 
 export const pageQuery = graphql`
-  query($category: String) {
+  query ($category: String) {
     allMarkdownRemark(
       limit: 2000
       sort: { fields: [frontmatter___date], order: DESC }

--- a/src/templates/posts.js
+++ b/src/templates/posts.js
@@ -6,6 +6,7 @@ import PrevNextPost from '../components/PrevNextPost'
 import MarkdownArticle from '../components/MarkdownArticle'
 import TagList from '../components/TagList'
 import Layout from '../components/Layout'
+import Seo from '../components/Seo'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import '../styles/blog.css'
@@ -30,7 +31,7 @@ function Template({
   onSetSidebarHide,
 }) {
   const { markdownRemark } = data // data.markdownRemark holds our post data
-  const { frontmatter, html, id } = markdownRemark
+  const { excerpt, frontmatter, html, id } = markdownRemark
 
   const hideAnchor =
     frontmatter.hideAnchor === null ? false : frontmatter.hideAnchor
@@ -46,6 +47,7 @@ function Template({
 
   return (
     <Layout location={location} onPostPage={true}>
+      <Seo title={frontmatter.title} description={excerpt} />
       <Wrapper>
         {frontmatter.showTitle && <Title>{frontmatter.title}</Title>}
         <Meta>
@@ -151,6 +153,7 @@ export const pageQuery = graphql`
       }
       id
       html
+      excerpt
       frontmatter {
         date(formatString: "YYYY-MM-DD")
         title

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,10 +6124,10 @@ gatsby-plugin-page-creator@^3.14.0:
     globby "^11.0.4"
     lodash "^4.17.21"
 
-gatsby-plugin-react-helmet@^4.6.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.14.0.tgz#69fe0bd90d65356a0aa144d4e8d75d2559638514"
-  integrity sha512-IpLC0mWRNP+E0ezDBXHciVATW+mv2MCvCP3lEYtFQ8mfcm3K//MpeynouNQSPCXn9cH7fr5w0Y355Wl5w1kw1A==
+gatsby-plugin-react-helmet@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.1.0.tgz#5387b87287d9827839056de5b0face1163168eaf"
+  integrity sha512-3NcVxbziBxCBGjbqCpQMndytLaeJeymgZsj+pdypH9Dq9g2dnm7/rFyk2PaZ7vngM4NWli7r9Q0XcKEFOohmPg==
   dependencies:
     "@babel/runtime" "^7.15.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6065,6 +6065,14 @@ gatsby-plugin-feed@^3.6.0:
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
+gatsby-plugin-google-gtag@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.1.0.tgz#75951cbe484ac5f1066062adc2df564cf9d68662"
+  integrity sha512-h2O90Lf/BdM2lmoox0OEumsKRyx8rI3kYL8uOtTvQDbsNGfrMC3iDAnb+V3l2oitm+ghvNW6AdCDyzwLpxMtKg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    minimatch "^3.0.4"
+
 gatsby-plugin-manifest@^3.6.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-3.14.0.tgz#1f17e35f2e51b86f627d74a6fd6ccfefc4968ddd"


### PR DESCRIPTION
## Why
- `UA-` から始まる Google Analytics が非推奨になり、代わりに `G-` から始まる gtag を使うようになった
- 1年前は gtag を使った Google Analytics の設定方法がよくわからなかったため放置したもののそろそろ知見が溜まってきたので対応したい
- また、meta の title や description がページごとに動的に設定されていなかったのでその修正も行いたい

## What
- gtag を用いた Google Analytics 対応を行った
- 主要ページの meta 情報を動的に変更した